### PR TITLE
Use docker images for hosting the project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.13-alpine
+
+COPY build /usr/share/nginx/html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := $(shell git describe --always)
-GCR_PROJECT := ishakuni-stag
-GCR_REGION := eu.gcr.io
+GCR_PROJECT ?= ishakuni-stag
+GCR_REGION ?= eu.gcr.io
 
 IMAGE_TAG = ${GCR_REGION}/${GCR_PROJECT}/frontend:${VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+VERSION := $(shell git describe --always)
+GCR_PROJECT := ishakuni-stag
+GCR_REGION := eu.gcr.io
+
+IMAGE_TAG = ${GCR_REGION}/${GCR_PROJECT}/frontend:${VERSION}
+
+.PHONY: build
+build:
+	yarn build
+	docker build -t ${IMAGE_TAG} .
+
+upload: build
+	docker push ${IMAGE_TAG}


### PR DESCRIPTION
We will use docker images based on nginx for hosting the project in a production kinda environment. The make targets allow building and uploading docker images to gcr. For example - `GCR_PROJECT=ishakuni-prod make upload` - to build and upload production image.