### PR TITLE
Add tests for checking seo meta tags

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -42,7 +42,8 @@
   "bs-dev-dependencies": [
     "@glennsl/bs-jest",
     "bs-jest-dom",
-    "bs-react-testing-library"
+    "bs-react-testing-library",
+    "bs-react-test-renderer"
   ],
   "bsc-flags": [
     "-bs-no-version-header",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bs-css": "^8.0.1",
     "bs-jest-dom": "^1.0.0",
     "bs-platform": "4.0.5",
+    "bs-react-test-renderer": "^2.0.0",
     "bs-react-testing-library": "^0.4.0",
     "gatsby": "2.0.22",
     "gatsby-plugin-manifest": "^2.0.19",

--- a/src/components/SEO.re
+++ b/src/components/SEO.re
@@ -1,0 +1,24 @@
+let component = ReasonReact.statelessComponent("SEO");
+
+let make = (~title, ~description, children) => {
+  ...component,
+  render: _ =>
+    <BsReactHelmet title>
+      <html lang="en" />
+      <meta name="description" content=description />
+      <meta property="og:url" content="https://ishakuni.com/" />
+      <meta
+        property="og:image"
+        content="https://ishakuni.com/icons/icon-512x512.png"
+      />
+      <meta name="og:title" content=title />
+      <meta name="og:description" content=description />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content=title />
+      <meta name="twitter:description" content=description />
+      <meta
+        name="twitter:image"
+        content="https://ishakuni.com/icons/icon-512x512.png"
+      />
+    </BsReactHelmet>,
+};

--- a/src/components/__tests__/SEO_test.re
+++ b/src/components/__tests__/SEO_test.re
@@ -1,0 +1,12 @@
+open Jest;
+open Expect;
+
+describe("SEO", () =>
+  test("renders with proper meta tags", () => {
+    let tree =
+      <SEO title="title" description="desc" />
+      |> ReactShallowRenderer.renderWithRenderer;
+
+    expect(tree) |> toMatchSnapshot;
+  })
+);

--- a/src/components/__tests__/__snapshots__/SEO_test.bs.js.snap
+++ b/src/components/__tests__/__snapshots__/SEO_test.bs.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SEO renders with proper meta tags 1`] = `
+<HelmetWrapper
+  defer={true}
+  encodeSpecialCharacters={true}
+  title="title"
+>
+  <html
+    lang="en"
+  />
+  <meta
+    content="desc"
+    name="description"
+  />
+  <meta
+    content="https://ishakuni.com/"
+    property="og:url"
+  />
+  <meta
+    content="https://ishakuni.com/icons/icon-512x512.png"
+    property="og:image"
+  />
+  <meta
+    content="title"
+    name="og:title"
+  />
+  <meta
+    content="desc"
+    name="og:description"
+  />
+  <meta
+    content="summary"
+    name="twitter:card"
+  />
+  <meta
+    content="title"
+    name="twitter:title"
+  />
+  <meta
+    content="desc"
+    name="twitter:description"
+  />
+  <meta
+    content="https://ishakuni.com/icons/icon-512x512.png"
+    name="twitter:image"
+  />
+</HelmetWrapper>
+`;

--- a/src/pages/index.re
+++ b/src/pages/index.re
@@ -2,24 +2,15 @@ let component = ReasonReact.statelessComponent("index");
 
 let container = Css.(style([textAlign(center)]));
 let moveDown = Css.(style([marginTop @@ em(2.)]));
-let title = "iShakuni | Fantasy bets";
-let description = "iShakuni is a fun platform to bet on sports events with friends using fictional money";
 
 let make = _ => {
   ...component,
   render: _ =>
     <main className=container>
-      <BsReactHelmet title>
-        <html lang="en" />
-        <meta name="description" content=description />
-        <meta property="og:url" content="https://ishakuni.com/" />
-        <meta
-          property="og:image"
-          content="https://ishakuni.com/icons/icon-512x512.png"
-        />
-        <meta name="og:title" content=title />
-        <meta name="og:description" content=description />
-      </BsReactHelmet>
+      <SEO
+        title="iShakuni | Fantasy bets"
+        description="iShakuni is a fun platform to bet on sports events with friends using fictional money"
+      />
       <div className=moveDown> <Logo /> </div>
       <H1> {ReasonReact.string("Fantasy bets")} </H1>
       <Text text="Content goes here" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,6 +2488,13 @@ bs-platform@4.0.5:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.5.tgz#d4fd9bbdd11765af5b75110a5655065ece05eed6"
   integrity sha512-wK+yUx/5ojlrxgk/EB3Hla7+9NEnE8PxtGb71e4IsKnWPXrRAaVtdTuoWWClv8z77xntOFg8qTgYfYyh9xLMWA==
 
+bs-react-test-renderer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bs-react-test-renderer/-/bs-react-test-renderer-2.0.0.tgz#a2f60f988e348dd83b2acd910bb1348508c9ece9"
+  integrity sha512-5wSV7Cn9LiNqnF4ztYrvyd1HQgqfHzVsVruf2YcVTLptTDAY1h4pLeXS/DCVtAEq3GXbhsXK1dzX6HRdPrlcDg==
+  dependencies:
+    react-test-renderer "^16.2.0"
+
 bs-react-testing-library@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/bs-react-testing-library/-/bs-react-testing-library-0.4.0.tgz#096bcc12f1023290ac393d763d0a108d6d678256"
@@ -9668,7 +9675,7 @@ react-hot-loader@^4.1.0:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-is@^16.8.1:
+react-is@^16.8.1, react-is@^16.8.3:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
@@ -9685,6 +9692,16 @@ react-side-effect@^1.1.0:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-test-renderer@^16.2.0:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.3.tgz#230006af264cc46aeef94392e04747c21839e05e"
+  integrity sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.3"
+    scheduler "^0.13.3"
 
 react-testing-library@^5.2.0:
   version "5.9.0"


### PR DESCRIPTION
Check meta-tags when the SEO component is rendered by comparing it with previous snapshot. Based on [react-test-renderer](https://github.com/facebook/react/tree/master/packages/react-test-renderer)

Related to #87